### PR TITLE
FIX: renamed 'delete' button in my bookings to 'cancel' booking

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -27,11 +27,22 @@ class BookingsController < ApplicationController
   def update
     @booking = Booking.find(params[:id])
     if @booking.update(status: booking_confirmation_params[:status].to_i)
-      redirect_to galaxies_path
-      # TODO: redirect to dashboard
+      # redirect to dashboard
+      redirect_to user_path(current_user)
     else
       render 'edit'
     end
+  end
+
+  def destroy
+    @booking = Booking.find(params[:id])
+    # TODO: WIP - trying to implement protection - so only customer can delete.
+    # if @booking[current_user] == @booking[:customer_id])
+      @booking.destroy
+      redirect_to user_path(@booking[:customer_id])
+    # else
+      # put 'error'
+    # end
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
-class PagesController < ApplicationController
+0-class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: :home
 
   def home

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
-0-class PagesController < ApplicationController
+class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: :home
 
   def home

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
         <div class="div card mb-4 shadow-sm rounded">
           <%= image_tag("https://images.unsplash.com/photo-1462331940025-496dfbfc7564?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1427&q=80", class: "card-img-top", alt: "...") %>
           <div class="div card-body">
-            <h5 class="font-weight-bold card-title"><%= galaxy.name %></h5>
+            <h5 class="font-weight-bold card-title"><%= link_to galaxy.name, galaxy_path(galaxy) %></h5>
             <p class="small text-muted card-text"><%= galaxy.description.truncate(100) %></p>
             <span class="label label-primary"><%= galaxy.owner.first_name %> <%= galaxy.owner.last_name%></span>
           </div>
@@ -27,7 +27,7 @@
         <div class="div card mb-4 shadow-sm rounded">
           <%= image_tag("https://images.unsplash.com/photo-1462331940025-496dfbfc7564?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1427&q=80", class: "card-img-top", alt: "...") %>
           <div class="div card-body">
-            <h5 class="font-weight-bold card-title"><%= booking.galaxy.name %></h5>
+            <h5 class="font-weight-bold card-title"><%= link_to booking.galaxy.name, galaxy_path(booking.galaxy)%></h5>
             <p class="small text-muted card-text"><%= booking.galaxy.description.truncate(100) %></p>
             <span class="label label-primary"><strong>Owner: </strong><%= booking.galaxy.owner.first_name %> <%= booking.galaxy.owner.last_name%></span>
             <p></p>
@@ -36,7 +36,7 @@
           </div>
           <div class="div card-footer">
             <span class="float-right">$<%= booking.galaxy.rate %>/night</span>
-            <%= link_to "Cancel booking", galaxy_path(booking.galaxy), method: :delete %>
+            <%= link_to "Cancel booking", booking_path(booking), method: :delete %>
           </div>
         </div>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,7 +36,7 @@
           </div>
           <div class="div card-footer">
             <span class="float-right">$<%= booking.galaxy.rate %>/night</span>
-            <%= link_to "Delete", galaxy_path(booking.galaxy), method: :delete %>
+            <%= link_to "Cancel booking", galaxy_path(booking.galaxy), method: :delete %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :users, only: [ :show ] do
     resources :galaxies, only: [ :index, :new, :create, :edit]
   end
-  resources :bookings, only: [ :edit, :update ]
+  resources :bookings, only: [ :edit, :update, :destroy ]
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# Pull Request
		
## Description :speak_no_evil:
user can delete / cancel his bookings from his dashboard.
included links to galaxy details from dashboard
![Screen Shot 2020-11-26 at 8 08 15 am](https://user-images.githubusercontent.com/70934030/100281763-9c72e800-2fbe-11eb-9736-d8c5d583c555.jpg)


		
## Changes :octopus:
- [ ] **Routes** added doobkings/id/destroy
- [ ] **Controller**: added destroy method
- [ ] **View**: edit `users/show.html.erb` to 
- incl links to galaxies 
- replaced _delete_ galaxy to _cancel booking_ button for 'my booked galaxies'

		
## How Has This Been Tested? :microscope:
- [x] Manual Testing
- [x] Visual Inspection